### PR TITLE
User bank account creation implemented

### DIFF
--- a/src/main/java/com/nexuspay/auth/infra/security/TokenService.java
+++ b/src/main/java/com/nexuspay/auth/infra/security/TokenService.java
@@ -24,13 +24,14 @@ public class TokenService implements TokenValidator {
     private String secret;
 
     public String generateToken(User user){
-        try{
-            Algorithm algorithm = Algorithm.HMAC256(secret);
+        Algorithm algorithm = Algorithm.HMAC256(secret);
+        List<String> roles = List.of("ROLE_" + user.getStatus().toString());
 
+        try{
             return JWT.create()
                     .withIssuer("nexuspay")
                     .withSubject(user.getId().toString())
-                    .withClaim("status", user.getStatus().toString())
+                    .withClaim("roles", roles)
                     .withClaim("email", user.getEmail())
                     .withExpiresAt(generateExpirationDate())
                     .sign(algorithm);
@@ -69,9 +70,9 @@ public class TokenService implements TokenValidator {
     public Collection<? extends GrantedAuthority> getAuthorities(String token) {
         try {
             DecodedJWT decoded = validateAndDecodeToken(token);
-            String status = decoded.getClaim("status").asString();
+            String roles = decoded.getClaim("roles").asString();
             // Transform the status (VERIFIED, PENDING) in a spring role
-            return List.of(new SimpleGrantedAuthority("ROLE_" + status));
+            return List.of(new SimpleGrantedAuthority("ROLE_" + roles));
         } catch (Exception e) {
             return List.of();
         }

--- a/src/main/java/com/nexuspay/auth/infra/security/WebSecurityConfig.java
+++ b/src/main/java/com/nexuspay/auth/infra/security/WebSecurityConfig.java
@@ -5,6 +5,7 @@ import com.nexuspay.shared.security.TokenValidator;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -16,6 +17,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity
 public class WebSecurityConfig {
 
     @Bean
@@ -27,7 +29,8 @@ public class WebSecurityConfig {
                 .sessionManagement(session ->
                         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(authorize -> authorize
-                        .requestMatchers("/api/v1/auth/**").permitAll()
+                        .requestMatchers("/api/v1/auth/register").permitAll()
+                        .requestMatchers("/api/v1/auth/verify", "/api/v1/ledger/transfer", "/api/v1/account").authenticated()
                         .anyRequest().authenticated()
                 ).addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
         return http.build();

--- a/src/main/java/com/nexuspay/ledger/application/AccountCreationUseCase.java
+++ b/src/main/java/com/nexuspay/ledger/application/AccountCreationUseCase.java
@@ -1,0 +1,36 @@
+package com.nexuspay.ledger.application;
+
+import com.nexuspay.ledger.application.dto.AccountResponseDTO;
+import com.nexuspay.ledger.domain.exception.BusinessException;
+import com.nexuspay.ledger.domain.model.Account;
+import com.nexuspay.ledger.domain.model.CurrencyCode;
+import com.nexuspay.ledger.domain.repository.AccountRepository;
+import jakarta.transaction.Transactional;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Service
+public class AccountCreationUseCase {
+    private final AccountRepository accountRepository;
+
+    public AccountCreationUseCase(AccountRepository accountRepository) {
+        this.accountRepository = accountRepository;
+    }
+
+    @Transactional
+    public AccountResponseDTO createAccount(UUID userId, CurrencyCode code){
+        if(accountRepository.existsByUserIdAndCurrencyCode(userId, code))
+            throw new BusinessException("User already have an account with this Currency Code");
+
+        Account account = new Account(userId, code);
+        accountRepository.save(account);
+        LocalDateTime timestamp = LocalDateTime.now();
+        return new AccountResponseDTO(
+                userId,
+                code,
+                timestamp
+        );
+    }
+}

--- a/src/main/java/com/nexuspay/ledger/application/dto/AccountRequestDTO.java
+++ b/src/main/java/com/nexuspay/ledger/application/dto/AccountRequestDTO.java
@@ -1,0 +1,8 @@
+package com.nexuspay.ledger.application.dto;
+
+import com.nexuspay.ledger.domain.model.CurrencyCode;
+
+public record AccountRequestDTO(
+        CurrencyCode code
+) {
+}

--- a/src/main/java/com/nexuspay/ledger/application/dto/AccountResponseDTO.java
+++ b/src/main/java/com/nexuspay/ledger/application/dto/AccountResponseDTO.java
@@ -1,0 +1,13 @@
+package com.nexuspay.ledger.application.dto;
+
+import com.nexuspay.ledger.domain.model.CurrencyCode;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record AccountResponseDTO(
+        UUID userId,
+        CurrencyCode code,
+        LocalDateTime timestamp
+) {
+}

--- a/src/main/java/com/nexuspay/ledger/domain/repository/AccountRepository.java
+++ b/src/main/java/com/nexuspay/ledger/domain/repository/AccountRepository.java
@@ -1,9 +1,11 @@
 package com.nexuspay.ledger.domain.repository;
 
 import com.nexuspay.ledger.domain.model.Account;
+import com.nexuspay.ledger.domain.model.CurrencyCode;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.UUID;
 
 public interface AccountRepository extends JpaRepository<Account, UUID> {
+    boolean existsByUserIdAndCurrencyCode(UUID userId, CurrencyCode code);
 }

--- a/src/main/java/com/nexuspay/ledger/web/AccountController.java
+++ b/src/main/java/com/nexuspay/ledger/web/AccountController.java
@@ -1,0 +1,31 @@
+package com.nexuspay.ledger.web;
+
+import com.nexuspay.ledger.application.AccountCreationUseCase;
+import com.nexuspay.ledger.application.dto.AccountRequestDTO;
+import com.nexuspay.ledger.application.dto.AccountResponseDTO;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1/account")
+public class AccountController {
+    private final AccountCreationUseCase creationUseCase;
+
+    public AccountController(AccountCreationUseCase useCase) {
+        this.creationUseCase = useCase;
+    }
+
+    @ResponseStatus(HttpStatus.CREATED)
+    @PreAuthorize("hasRole('VERIFIED')")
+    public AccountResponseDTO create(@AuthenticationPrincipal UUID userId, @RequestBody @Valid AccountRequestDTO dto){
+        return creationUseCase.createAccount(userId , dto.code());
+    }
+}

--- a/src/test/java/com/nexuspay/ledger/application/AccountCreationUseCaseTest.java
+++ b/src/test/java/com/nexuspay/ledger/application/AccountCreationUseCaseTest.java
@@ -1,0 +1,55 @@
+package com.nexuspay.ledger.application;
+
+import com.nexuspay.ledger.application.dto.AccountResponseDTO;
+import com.nexuspay.ledger.domain.exception.BusinessException;
+import com.nexuspay.ledger.domain.model.CurrencyCode;
+import com.nexuspay.ledger.domain.repository.AccountRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AccountCreationUseCaseTest {
+    @Mock
+    AccountRepository accountRepository;
+    @InjectMocks
+    AccountCreationUseCase creationUseCase;
+
+    @Test
+    @DisplayName("Must successfully create an account with a currency code not yet used by the user")
+    void createAccountSuccess(){
+        when(accountRepository.existsByUserIdAndCurrencyCode(any(UUID.class), any(CurrencyCode.class)))
+                .thenReturn(false);
+        UUID userId = UUID.randomUUID();
+        CurrencyCode cc = CurrencyCode.EUR;
+
+        AccountResponseDTO dto = creationUseCase.createAccount(userId, cc);
+
+        assertEquals(userId, dto.userId());
+        assertEquals(cc, dto.code());
+    }
+
+    @Test
+    @DisplayName("Must throw an Business exception when trying an already used pair of ID + currency code")
+    void createAccountException(){
+        when(accountRepository.existsByUserIdAndCurrencyCode(any(UUID.class), any(CurrencyCode.class)))
+                .thenReturn(true);
+        UUID userId = UUID.randomUUID();
+        CurrencyCode cc = CurrencyCode.EUR;
+
+        BusinessException ex = assertThrows(BusinessException.class,
+                () -> creationUseCase.createAccount(userId, cc));
+
+        assertEquals("User already have an account with this Currency Code", ex.getMessage());
+    }
+}

--- a/src/test/java/com/nexuspay/ledger/web/AccountControllerTest.java
+++ b/src/test/java/com/nexuspay/ledger/web/AccountControllerTest.java
@@ -1,0 +1,56 @@
+package com.nexuspay.ledger.web;
+
+import com.nexuspay.ledger.application.AccountCreationUseCase;
+import com.nexuspay.ledger.application.dto.AccountResponseDTO;
+import com.nexuspay.ledger.domain.model.CurrencyCode;
+import com.nexuspay.shared.security.TokenValidator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(AccountController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class AccountControllerTest {
+    @Autowired
+    MockMvc mockMvc;
+    @MockitoBean
+    AccountCreationUseCase useCase;
+
+    @MockitoBean
+    TokenValidator tokenValidator;
+
+    UUID userId = UUID.randomUUID();
+    AccountResponseDTO responseDTO = new AccountResponseDTO(userId, CurrencyCode.JPY, LocalDateTime.now());
+
+    @Test
+    void createMethodSuccess() throws Exception {
+        when(useCase.createAccount(nullable(UUID.class), any(CurrencyCode.class)))
+                .thenReturn(responseDTO);
+
+        mockMvc.perform(post("/api/v1/account")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                            {
+                                "code": "JPY"
+                            }
+                            """))
+                .andExpect(status().isCreated())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.userId").value(userId.toString()))
+                .andExpect(jsonPath("$.code").value("JPY"));
+
+        verify(useCase, times(1)).createAccount(any(), any());
+    }
+}


### PR DESCRIPTION
With this functionality, a user can create their account by choosing the Currency Code they wish to use.

I implemented a UseCase service to facilitate the creation of tests and maintain this class with a single responsibility.

I changed the claim of the JWT generated from status -> roles, to insert a collection in the context of authorities that will be used to ensure that an unverified user does not use protected endpoints. I added the new uri to filterChain.

Closes #1